### PR TITLE
solve problem that empty-password account login will fail.

### DIFF
--- a/Plugins/LocalMachine/Configuration.Designer.cs
+++ b/Plugins/LocalMachine/Configuration.Designer.cs
@@ -38,6 +38,8 @@
             this.m_chkAuthzLocalAdmin = new System.Windows.Forms.CheckBox();
             this.m_chkAuthzAll = new System.Windows.Forms.CheckBox();
             this.groupBox3 = new System.Windows.Forms.GroupBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this.m_chkScrambleWhenLMFails = new System.Windows.Forms.CheckBox();
             this.m_scrambleAllExceptDGV = new System.Windows.Forms.DataGridView();
             this.Username = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.m_chkRemoveProfile = new System.Windows.Forms.CheckBox();
@@ -47,8 +49,7 @@
             this.Group = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.m_btnSave = new System.Windows.Forms.Button();
             this.m_btnClose = new System.Windows.Forms.Button();
-            this.m_chkScrambleWhenLMFails = new System.Windows.Forms.CheckBox();
-            this.label1 = new System.Windows.Forms.Label();
+            this.m_chkAllowForEmptyPassword = new System.Windows.Forms.CheckBox();
             this.groupBox1.SuspendLayout();
             this.groupBox2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.m_localGroupDgv)).BeginInit();
@@ -59,10 +60,11 @@
             // 
             // groupBox1
             // 
+            this.groupBox1.Controls.Add(this.m_chkAllowForEmptyPassword);
             this.groupBox1.Controls.Add(this.m_chkAlwaysAuth);
-            this.groupBox1.Location = new System.Drawing.Point(13, 13);
+            this.groupBox1.Location = new System.Drawing.Point(13, 12);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(342, 54);
+            this.groupBox1.Size = new System.Drawing.Size(388, 67);
             this.groupBox1.TabIndex = 0;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Authentication";
@@ -70,9 +72,9 @@
             // m_chkAlwaysAuth
             // 
             this.m_chkAlwaysAuth.AutoSize = true;
-            this.m_chkAlwaysAuth.Location = new System.Drawing.Point(15, 23);
+            this.m_chkAlwaysAuth.Location = new System.Drawing.Point(15, 21);
             this.m_chkAlwaysAuth.Name = "m_chkAlwaysAuth";
-            this.m_chkAlwaysAuth.Size = new System.Drawing.Size(174, 17);
+            this.m_chkAlwaysAuth.Size = new System.Drawing.Size(210, 16);
             this.m_chkAlwaysAuth.TabIndex = 0;
             this.m_chkAlwaysAuth.Text = "Always authenticate local users";
             this.m_chkAlwaysAuth.UseVisualStyleBackColor = true;
@@ -84,9 +86,9 @@
             this.groupBox2.Controls.Add(this.m_localGroupDgv);
             this.groupBox2.Controls.Add(this.m_chkAuthzLocalAdmin);
             this.groupBox2.Controls.Add(this.m_chkAuthzAll);
-            this.groupBox2.Location = new System.Drawing.Point(12, 73);
+            this.groupBox2.Location = new System.Drawing.Point(12, 84);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(343, 333);
+            this.groupBox2.Size = new System.Drawing.Size(389, 290);
             this.groupBox2.TabIndex = 1;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Authorization";
@@ -94,9 +96,9 @@
             // m_chkMirror
             // 
             this.m_chkMirror.AutoSize = true;
-            this.m_chkMirror.Location = new System.Drawing.Point(15, 21);
+            this.m_chkMirror.Location = new System.Drawing.Point(15, 19);
             this.m_chkMirror.Name = "m_chkMirror";
-            this.m_chkMirror.Size = new System.Drawing.Size(158, 17);
+            this.m_chkMirror.Size = new System.Drawing.Size(198, 16);
             this.m_chkMirror.TabIndex = 4;
             this.m_chkMirror.Text = "Mirror groups from local user";
             this.m_chkMirror.UseVisualStyleBackColor = true;
@@ -104,9 +106,9 @@
             // m_chkAuthzRequireLocal
             // 
             this.m_chkAuthzRequireLocal.AutoSize = true;
-            this.m_chkAuthzRequireLocal.Location = new System.Drawing.Point(16, 90);
+            this.m_chkAuthzRequireLocal.Location = new System.Drawing.Point(16, 83);
             this.m_chkAuthzRequireLocal.Name = "m_chkAuthzRequireLocal";
-            this.m_chkAuthzRequireLocal.Size = new System.Drawing.Size(291, 17);
+            this.m_chkAuthzRequireLocal.Size = new System.Drawing.Size(360, 16);
             this.m_chkAuthzRequireLocal.TabIndex = 3;
             this.m_chkAuthzRequireLocal.Text = "Require membership in one of the following local groups:";
             this.m_chkAuthzRequireLocal.UseVisualStyleBackColor = true;
@@ -117,9 +119,9 @@
             this.m_localGroupDgv.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.m_localGroupDgv.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.LocalGroup});
-            this.m_localGroupDgv.Location = new System.Drawing.Point(15, 113);
+            this.m_localGroupDgv.Location = new System.Drawing.Point(15, 104);
             this.m_localGroupDgv.Name = "m_localGroupDgv";
-            this.m_localGroupDgv.Size = new System.Drawing.Size(311, 200);
+            this.m_localGroupDgv.Size = new System.Drawing.Size(311, 168);
             this.m_localGroupDgv.TabIndex = 2;
             // 
             // LocalGroup
@@ -131,9 +133,9 @@
             // m_chkAuthzLocalAdmin
             // 
             this.m_chkAuthzLocalAdmin.AutoSize = true;
-            this.m_chkAuthzLocalAdmin.Location = new System.Drawing.Point(15, 67);
+            this.m_chkAuthzLocalAdmin.Location = new System.Drawing.Point(15, 62);
             this.m_chkAuthzLocalAdmin.Name = "m_chkAuthzLocalAdmin";
-            this.m_chkAuthzLocalAdmin.Size = new System.Drawing.Size(239, 17);
+            this.m_chkAuthzLocalAdmin.Size = new System.Drawing.Size(288, 16);
             this.m_chkAuthzLocalAdmin.TabIndex = 1;
             this.m_chkAuthzLocalAdmin.Text = "Require local administrator group membership";
             this.m_chkAuthzLocalAdmin.UseVisualStyleBackColor = true;
@@ -141,9 +143,9 @@
             // m_chkAuthzAll
             // 
             this.m_chkAuthzAll.AutoSize = true;
-            this.m_chkAuthzAll.Location = new System.Drawing.Point(15, 44);
+            this.m_chkAuthzAll.Location = new System.Drawing.Point(15, 41);
             this.m_chkAuthzAll.Name = "m_chkAuthzAll";
-            this.m_chkAuthzAll.Size = new System.Drawing.Size(179, 17);
+            this.m_chkAuthzAll.Size = new System.Drawing.Size(222, 16);
             this.m_chkAuthzAll.TabIndex = 0;
             this.m_chkAuthzAll.Text = "Authorize all authenticated users";
             this.m_chkAuthzAll.UseVisualStyleBackColor = true;
@@ -157,21 +159,40 @@
             this.groupBox3.Controls.Add(this.m_chkScramble);
             this.groupBox3.Controls.Add(this.m_chkGroupFailIsFAIL);
             this.groupBox3.Controls.Add(this.m_groupsDgv);
-            this.groupBox3.Location = new System.Drawing.Point(361, 13);
+            this.groupBox3.Location = new System.Drawing.Point(407, 11);
             this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Size = new System.Drawing.Size(343, 393);
+            this.groupBox3.Size = new System.Drawing.Size(392, 363);
             this.groupBox3.TabIndex = 2;
             this.groupBox3.TabStop = false;
             this.groupBox3.Text = "Gateway";
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(51, 125);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(293, 12);
+            this.label1.TabIndex = 13;
+            this.label1.Text = "Never scramble the passwords for these accounts:";
+            // 
+            // m_chkScrambleWhenLMFails
+            // 
+            this.m_chkScrambleWhenLMFails.AutoSize = true;
+            this.m_chkScrambleWhenLMFails.Location = new System.Drawing.Point(37, 93);
+            this.m_chkScrambleWhenLMFails.Name = "m_chkScrambleWhenLMFails";
+            this.m_chkScrambleWhenLMFails.Size = new System.Drawing.Size(360, 28);
+            this.m_chkScrambleWhenLMFails.TabIndex = 12;
+            this.m_chkScrambleWhenLMFails.Text = "Only scramble when LocalMachine authentication fails or \r\ndoes not execute.";
+            this.m_chkScrambleWhenLMFails.UseVisualStyleBackColor = true;
             // 
             // m_scrambleAllExceptDGV
             // 
             this.m_scrambleAllExceptDGV.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.m_scrambleAllExceptDGV.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.Username});
-            this.m_scrambleAllExceptDGV.Location = new System.Drawing.Point(54, 154);
+            this.m_scrambleAllExceptDGV.Location = new System.Drawing.Point(54, 142);
             this.m_scrambleAllExceptDGV.Name = "m_scrambleAllExceptDGV";
-            this.m_scrambleAllExceptDGV.Size = new System.Drawing.Size(271, 84);
+            this.m_scrambleAllExceptDGV.Size = new System.Drawing.Size(271, 78);
             this.m_scrambleAllExceptDGV.TabIndex = 11;
             // 
             // Username
@@ -183,9 +204,9 @@
             // m_chkRemoveProfile
             // 
             this.m_chkRemoveProfile.AutoSize = true;
-            this.m_chkRemoveProfile.Location = new System.Drawing.Point(15, 42);
+            this.m_chkRemoveProfile.Location = new System.Drawing.Point(15, 39);
             this.m_chkRemoveProfile.Name = "m_chkRemoveProfile";
-            this.m_chkRemoveProfile.Size = new System.Drawing.Size(290, 30);
+            this.m_chkRemoveProfile.Size = new System.Drawing.Size(342, 28);
             this.m_chkRemoveProfile.TabIndex = 8;
             this.m_chkRemoveProfile.Text = "Remove account and profile after logout when account \r\ndoes not exist prior to lo" +
     "gon.";
@@ -195,9 +216,9 @@
             // m_chkScramble
             // 
             this.m_chkScramble.AutoSize = true;
-            this.m_chkScramble.Location = new System.Drawing.Point(15, 78);
+            this.m_chkScramble.Location = new System.Drawing.Point(15, 72);
             this.m_chkScramble.Name = "m_chkScramble";
-            this.m_chkScramble.Size = new System.Drawing.Size(177, 17);
+            this.m_chkScramble.Size = new System.Drawing.Size(210, 16);
             this.m_chkScramble.TabIndex = 7;
             this.m_chkScramble.Text = "Scramble password after logout.";
             this.m_chkScramble.UseVisualStyleBackColor = true;
@@ -206,9 +227,9 @@
             // m_chkGroupFailIsFAIL
             // 
             this.m_chkGroupFailIsFAIL.AutoSize = true;
-            this.m_chkGroupFailIsFAIL.Location = new System.Drawing.Point(15, 19);
+            this.m_chkGroupFailIsFAIL.Location = new System.Drawing.Point(15, 18);
             this.m_chkGroupFailIsFAIL.Name = "m_chkGroupFailIsFAIL";
-            this.m_chkGroupFailIsFAIL.Size = new System.Drawing.Size(291, 17);
+            this.m_chkGroupFailIsFAIL.Size = new System.Drawing.Size(378, 16);
             this.m_chkGroupFailIsFAIL.TabIndex = 6;
             this.m_chkGroupFailIsFAIL.Text = "Failure to create or join local groups should prevent login";
             this.m_chkGroupFailIsFAIL.UseVisualStyleBackColor = true;
@@ -218,9 +239,9 @@
             this.m_groupsDgv.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.m_groupsDgv.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.Group});
-            this.m_groupsDgv.Location = new System.Drawing.Point(15, 262);
+            this.m_groupsDgv.Location = new System.Drawing.Point(15, 242);
             this.m_groupsDgv.Name = "m_groupsDgv";
-            this.m_groupsDgv.Size = new System.Drawing.Size(311, 111);
+            this.m_groupsDgv.Size = new System.Drawing.Size(311, 102);
             this.m_groupsDgv.TabIndex = 5;
             // 
             // Group
@@ -231,9 +252,9 @@
             // 
             // m_btnSave
             // 
-            this.m_btnSave.Location = new System.Drawing.Point(533, 412);
+            this.m_btnSave.Location = new System.Drawing.Point(533, 380);
             this.m_btnSave.Name = "m_btnSave";
-            this.m_btnSave.Size = new System.Drawing.Size(75, 23);
+            this.m_btnSave.Size = new System.Drawing.Size(75, 21);
             this.m_btnSave.TabIndex = 3;
             this.m_btnSave.Text = "Save";
             this.m_btnSave.UseVisualStyleBackColor = true;
@@ -241,38 +262,29 @@
             // 
             // m_btnClose
             // 
-            this.m_btnClose.Location = new System.Drawing.Point(618, 412);
+            this.m_btnClose.Location = new System.Drawing.Point(618, 380);
             this.m_btnClose.Name = "m_btnClose";
-            this.m_btnClose.Size = new System.Drawing.Size(75, 23);
+            this.m_btnClose.Size = new System.Drawing.Size(75, 21);
             this.m_btnClose.TabIndex = 4;
             this.m_btnClose.Text = "Close";
             this.m_btnClose.UseVisualStyleBackColor = true;
             this.m_btnClose.Click += new System.EventHandler(this.m_btnClose_Click);
             // 
-            // m_chkScrambleWhenLMFails
+            // m_chkAllowForEmptyPassword
             // 
-            this.m_chkScrambleWhenLMFails.AutoSize = true;
-            this.m_chkScrambleWhenLMFails.Location = new System.Drawing.Point(37, 101);
-            this.m_chkScrambleWhenLMFails.Name = "m_chkScrambleWhenLMFails";
-            this.m_chkScrambleWhenLMFails.Size = new System.Drawing.Size(297, 30);
-            this.m_chkScrambleWhenLMFails.TabIndex = 12;
-            this.m_chkScrambleWhenLMFails.Text = "Only scramble when LocalMachine authentication fails or \r\ndoes not execute.";
-            this.m_chkScrambleWhenLMFails.UseVisualStyleBackColor = true;
-            // 
-            // label1
-            // 
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(51, 135);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(246, 13);
-            this.label1.TabIndex = 13;
-            this.label1.Text = "Never scramble the passwords for these accounts:";
+            this.m_chkAllowForEmptyPassword.AutoSize = true;
+            this.m_chkAllowForEmptyPassword.Location = new System.Drawing.Point(15, 43);
+            this.m_chkAllowForEmptyPassword.Name = "m_chkAllowForEmptyPassword";
+            this.m_chkAllowForEmptyPassword.Size = new System.Drawing.Size(168, 16);
+            this.m_chkAllowForEmptyPassword.TabIndex = 1;
+            this.m_chkAllowForEmptyPassword.Text = "Allow For Empty Password";
+            this.m_chkAllowForEmptyPassword.UseVisualStyleBackColor = true;
             // 
             // Configuration
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 12F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(720, 447);
+            this.ClientSize = new System.Drawing.Size(811, 409);
             this.Controls.Add(this.m_btnClose);
             this.Controls.Add(this.m_btnSave);
             this.Controls.Add(this.groupBox3);
@@ -316,5 +328,6 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn Username;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.CheckBox m_chkScrambleWhenLMFails;
+        private System.Windows.Forms.CheckBox m_chkAllowForEmptyPassword;
     }
 }

--- a/Plugins/LocalMachine/Configuration.cs
+++ b/Plugins/LocalMachine/Configuration.cs
@@ -57,6 +57,7 @@ namespace pGina.Plugin.LocalMachine
             bool RemoveProfiles = Settings.Store.RemoveProfiles;
             bool scrWhenLMFail = Settings.Store.ScramblePasswordsWhenLMAuthFails;
             string[] scrambleExceptions = Settings.Store.ScramblePasswordsExceptions;
+            bool AllowForEmptyPassword = Settings.Store.AllowForEmptyPassword;
 
             m_chkAlwaysAuth.Checked = AlwaysAuthenticate;
             m_chkAuthzLocalAdmin.Checked = AuthzLocalAdminsOnly;
@@ -64,6 +65,7 @@ namespace pGina.Plugin.LocalMachine
             m_chkScramble.Checked = ScramblePasswords;
             m_chkRemoveProfile.Checked = RemoveProfiles;
             m_chkScrambleWhenLMFails.Checked = scrWhenLMFail;
+            m_chkAllowForEmptyPassword.Checked = AllowForEmptyPassword;
 
             foreach (string group in AuthzLocalGroups)
             {
@@ -96,6 +98,7 @@ namespace pGina.Plugin.LocalMachine
             Settings.Store.ScramblePasswords = m_chkScramble.Checked;
             Settings.Store.RemoveProfiles = m_chkRemoveProfile.Checked;
             Settings.Store.ScramblePasswordsWhenLMAuthFails = m_chkScrambleWhenLMFails.Checked;
+            Settings.Store.AllowForEmptyPassword = m_chkAllowForEmptyPassword.Checked;
 
             List<string> localGroups = new List<string>();
             foreach (DataGridViewRow row in m_localGroupDgv.Rows)

--- a/Plugins/LocalMachine/Configuration.resx
+++ b/Plugins/LocalMachine/Configuration.resx
@@ -120,15 +120,6 @@
   <metadata name="LocalGroup.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="LocalGroup.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="Username.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="Group.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
   <metadata name="Username.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>

--- a/Plugins/LocalMachine/Settings.cs
+++ b/Plugins/LocalMachine/Settings.cs
@@ -60,6 +60,7 @@ namespace pGina.Plugin.LocalMachine
             // Cleanup thread settings (not user configurable)
             m_settings.SetDefault("CleanupUsers", new string[] { });     // List of principal names we must cleanup!
             m_settings.SetDefault("BackgroundTimerSeconds", 60);         // How often we look to cleanup
+            m_settings.SetDefault("AllowForEmptyPassword", false);         // Allow Empty Password Login (no matter in which group)
         }
 
         public static dynamic Store


### PR DESCRIPTION
adds a CheckBox and a setting item into Plugin LocalMachine.

this Function will be disabled by default.
# 

if you do not notice it, you may using an account in group administrators. view log for any line contains "fall back to ..." to find this problem.
