### PR TITLE
LocalMachine: Fix "require local group membership" setting

### DIFF
--- a/Plugins/Core/LocalMachine/PluginImpl.cs
+++ b/Plugins/Core/LocalMachine/PluginImpl.cs
@@ -305,16 +305,17 @@ namespace pGina.Plugin.LocalMachine
                     {
                         foreach (string group in limitToGroupList)
                         {
-                            if (!ListedInGroup(group, null, properties))
+                            if (ListedInGroup(group, null, properties))
                             {
-                                return new BooleanResult()
-                                {
-                                    Success = false,
-                                    Message = string.Format("Users group list does not include the required group ({0}), denying access", group)
-                                };
+                                return new BooleanResult() { Success = true };
                             }
                         }
                     }
+                    return new BooleanResult()
+                    {
+                        Success = false,
+                        Message = "User is not a member of one of the required groups, denying access"
+                    };
                 }
 
                 return new BooleanResult() { Success = true };


### PR DESCRIPTION
If the authorization option "require membership in one of the following local groups" is set and multiple groups are specified, the Local Machine plugin currently denies access unless the user is a member of _all_ those groups.  The documentation says that access should only be denied if the user is not in _any_ of the specified groups.  This commit changes the behaviour accordingly.
