### PR TITLE
Use credentials provided by remote clients

### DIFF
--- a/pGina/src/CredentialProvider/Credential.cpp
+++ b/pGina/src/CredentialProvider/Credential.cpp
@@ -466,6 +466,12 @@ namespace pGina
 			if(username != NULL)
 			{				
 				SHStrDupW(username, &(m_fields->fields[m_fields->usernameFieldIdx].wstr));
+
+				// If the username field has focus, hand focus over to the password field
+				if(m_fields->fields[m_fields->usernameFieldIdx].fieldStatePair.fieldInteractiveState == CPFIS_FOCUSED) {
+					m_fields->fields[m_fields->usernameFieldIdx].fieldStatePair.fieldInteractiveState = CPFIS_NONE;
+					m_fields->fields[m_fields->passwordFieldIdx].fieldStatePair.fieldInteractiveState = CPFIS_FOCUSED;
+				}
 			}
 			else if(m_usageScenario == CPUS_UNLOCK_WORKSTATION)
 			{

--- a/pGina/src/CredentialProvider/CredentialProviderFilter.cpp
+++ b/pGina/src/CredentialProvider/CredentialProviderFilter.cpp
@@ -29,6 +29,7 @@
 #include "CredentialProviderFilter.h"
 
 #include "Dll.h"
+#include "ProviderGuid.h"
 
 #pragma warning(push)
 #pragma warning(disable : 4995)
@@ -141,8 +142,22 @@ namespace pGina {
             /* [in] */ const CREDENTIAL_PROVIDER_CREDENTIAL_SERIALIZATION *pcpcsIn,
             /* [out] */ CREDENTIAL_PROVIDER_CREDENTIAL_SERIALIZATION *pcpcsOut)
 		{
-			pDEBUG(L"CredentialProviderFilter::UpdateRemoteCredential: not implemented");
-			return E_NOTIMPL;
+			HRESULT result;
+
+			if( pcpcsIn != NULL && pcpcsIn->cbSerialization > 0
+				&& (pcpcsOut->rgbSerialization = (BYTE *)CoTaskMemAlloc(pcpcsIn->cbSerialization)) != NULL )
+			{
+				pcpcsOut->ulAuthenticationPackage = pcpcsIn->ulAuthenticationPackage;
+				pcpcsOut->clsidCredentialProvider = CLSID_CpGinaProvider;
+				pcpcsOut->cbSerialization = pcpcsIn->cbSerialization;
+				CopyMemory(pcpcsOut->rgbSerialization, pcpcsIn->rgbSerialization, pcpcsIn->cbSerialization);
+				result = S_OK;
+			}
+			else
+				result = S_FALSE;
+
+			pDEBUG(L"CredentialProviderFilter::UpdateRemoteCredential(%p) returns %ld", pcpcsIn, result);
+			return result;
 		}
 
 		CredentialProviderFilter::CredentialProviderFilter(void) :

--- a/pGina/src/CredentialProvider/Provider.h
+++ b/pGina/src/CredentialProvider/Provider.h
@@ -65,7 +65,9 @@ namespace pGina
 			__override ~Provider();
 
 			IFACEMETHODIMP GetFieldDescriptorForUi(UI_FIELDS const& fields, DWORD index, CREDENTIAL_PROVIDER_FIELD_DESCRIPTOR **ppcpfd);
-			bool SerializedCredsAppearComplete();
+			bool SerializedUserNameAvailable();
+			bool SerializedPasswordAvailable();
+			bool SerializedDomainNameAvailable();
 			void GetSerializedCredentials(PWSTR *username, PWSTR *password, PWSTR *domain);			
 
 		private:


### PR DESCRIPTION
If a remote client provides a username, fill in the corresponding field of the logon user interface (and focus the password field).  If the client also provides a password, attempt an auto-login.

This patch works fine for us on Windows Server 2008 R2, but I see two possible caveats:
- As I [mentioned on the mailing list](https://groups.google.com/forum/#!topic/pgina-devel/DLDwueNMGuE), it might introduce a memory leak.  The UpdateRemoteCredential callback allocates space for pcpcsOut->rgbSerialization, and it's not obvious to me whether I'm supposed to release that memory myself; and if so, where.
- According to [a forum thread on MSDN](http://social.msdn.microsoft.com/Forums/windowsdesktop/en-US/4134d896-85f5-460e-b621-c3b8acf3a1c9/credential-provider-icredentialprovidersetserialization-is-never-called), this implementation of the feature won't work on Windows releases older than Windows 7 or Server 2008 R2.  However, the code shouldn't hurt these platforms, it will simply be unused.
